### PR TITLE
Restructure app to use actor architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,329 +130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "aws-config"
-version = "1.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7198e6f03240fdceba36656d8be440297b6b82270325908c7381f37d826a74f6"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
- "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "hex",
- "http 0.2.12",
- "ring",
- "time",
- "tokio",
- "tracing",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "aws-credential-types"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "zeroize",
-]
-
-[[package]]
-name = "aws-runtime"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
-dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "aws-sdk-cloudwatchlogs"
-version = "1.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59340973410bfadb6091a3823c7d23dbb1359216f6b8212a9a248ef13d2f79"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc2faec3205d496c7e57eff685dd944203df7ce16a4116d0281c44021788a7b"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c93c241f52bc5e0476e259c953234dab7e2a35ee207ee202e86c0095ec4951dc"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sts"
-version = "1.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b259429be94a3459fa1b00c5684faee118d74f9577cc50aebadc36e507c63b5f"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-query",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8db6904450bafe7473c6ca9123f88cc11089e41a025408f992db4e22d3be68"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "form_urlencoded",
- "hex",
- "hmac",
- "http 0.2.12",
- "http 1.1.0",
- "once_cell",
- "percent-encoding",
- "sha2",
- "time",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-async"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.60.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.60.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-query"
-version = "0.60.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
-dependencies = [
- "aws-smithy-types",
- "urlencoding",
-]
-
-[[package]]
-name = "aws-smithy-runtime"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "fastrand",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "httparse",
- "hyper",
- "hyper-rustls",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "rustls",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
- "bytes",
- "http 0.2.12",
- "http 1.1.0",
- "pin-project-lite",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "1.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b"
-dependencies = [
- "base64-simd",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http 1.1.0",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "num-integer",
- "pin-project-lite",
- "pin-utils",
- "ryu",
- "serde",
- "time",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "aws-smithy-xml"
-version = "0.60.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
-name = "aws-types"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "rustc_version",
- "tracing",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,35 +154,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref",
- "vsimd",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "bumpalo"
@@ -532,23 +184,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
-name = "bytes-utils"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
-dependencies = [
- "bytes",
- "either",
-]
-
-[[package]]
 name = "canary"
 version = "0.1.0-alpha.1"
 dependencies = [
  "async-stream",
  "async-trait",
- "aws-config",
- "aws-sdk-cloudwatchlogs",
  "chrono",
  "clap",
  "futures-core",
@@ -640,77 +280,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
-]
-
-[[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -720,36 +299,6 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
 ]
 
 [[package]]
@@ -768,12 +317,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -796,16 +339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,31 +356,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,129 +366,6 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http 1.1.0",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
-dependencies = [
- "bytes",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "0.14.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper",
- "log",
- "rustls",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -1003,26 +388,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
-dependencies = [
- "equivalent",
- "hashbrown",
 ]
 
 [[package]]
@@ -1193,12 +558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,18 +602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "outref"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
-
-[[package]]
 name = "owo-colors"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,12 +637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,12 +647,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1406,40 +741,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "ring"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom",
- "libc",
- "spin",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"
@@ -1452,49 +757,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki",
- "sct",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -1513,58 +775,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -1596,17 +810,6 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -1669,12 +872,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,12 +894,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -1778,51 +969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
-name = "tinyvec"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,16 +998,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,72 +1009,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tracing"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -1953,75 +1027,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "url"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
 
 [[package]]
 name = "wasi"
@@ -2117,15 +1132,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2252,12 +1258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
-
-[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,9 +1283,3 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/bin/main.rs"
 [dependencies]
 async-stream = "0.3.6"
 async-trait = "0.1.83"
-aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
-aws-sdk-cloudwatchlogs = "1.52.0"
+# aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
+# aws-sdk-cloudwatchlogs = "1.52.0"
 chrono = "0.4.38"
 clap = { version = "4.3", features = ["derive"] }
 futures-core = "0.3.31"
@@ -42,4 +42,12 @@ static_assertions = "1.1"
 [profile.dist]
 inherits = "release"
 lto = "thin"
+# This enables Clippy lints for the entire crate.
+# Lints that are configurable have their config set in .clippy.toml (currently none)
+# Note that Rustdoc lints can only be configured in source code (see lib.rs)
+# [lints.clippy]
+# pedantic = "deny"
 
+[lints.rust]
+dead_code = "allow"
+unsafe_code = "forbid"

--- a/src/adapters/engines/action.rs
+++ b/src/adapters/engines/action.rs
@@ -1,0 +1,17 @@
+/// An [Action] describes an effectful operation affecting the deployments.
+/// Actions describe decisions made by the [DecisionEngine].
+pub enum Action {
+    /// Ramp the canary to 100% traffic and decommission the control deployment.
+    Promote,
+    /// Ramp the control to 100% traffic and decommission the canary deployment.
+    Yank,
+    /// RampUp indicates the amount of traffic provided to the canary should increase
+    /// by one unit.
+    RampUp,
+    /// RampDown indicates the amount of traffic provided to the canary should decrease.
+    RampDown,
+    // NB: We don't have a no-op action type, which might be something the DecisionEngine
+    //     provides, except that I'm picturing this Action type as part of the interface
+    //     into the Ingress, so the Ingress just won't hear back anything from the engine
+    //     if that's the case.
+}

--- a/src/adapters/engines/controller.rs
+++ b/src/adapters/engines/controller.rs
@@ -1,0 +1,88 @@
+use async_stream::stream;
+use futures_core::Stream;
+use tokio::{pin, select, time::interval};
+use tokio_stream::wrappers::IntervalStream;
+use tokio_stream::StreamExt;
+
+use super::{Action, DecisionEngine, HashableCategory};
+
+/// An [EngineController] is a wrapper around a DecisionEngine that
+/// controls how and when its called. It essentially converts the
+/// [DecisionEngine] into an async stream that only emits [Action]s
+/// when there's an action to take.
+pub struct EngineController {
+    // TODO: Implement these fields.
+    // Only run engine if this many samples
+    // has been received.
+    // minimum_samples: u64,
+    // Always run the engine if this many samples has been received.
+    // maximum_samples: u64,
+    // If this amount of time has elapsed, and the minimum number of samples
+    // has been received, then run the engine.
+    // minimum_duration: tokio::time::Duration,
+    // If this amount of time has elapsed, run the engine even if the
+    // minimum number of samples has not yet been reached.
+    maximum_duration: tokio::time::Duration,
+    // receive a shutdown signal.
+    // shutdown: Receiver<()>,
+}
+
+impl EngineController {
+    /// Convert this controller into a stream that emits [Action]s from the Engine.
+    pub fn run<T: HashableCategory>(
+        self,
+        mut engine: impl DecisionEngine<T>,
+        observations: impl Stream<Item = Vec<T>>,
+    ) -> impl Stream<Item = Action> {
+        stream! {
+            // TODO: Implement the stream controls.
+            let timer = IntervalStream::new(interval(self.maximum_duration));
+            // Pin our streams to the stack for iteration.
+            pin!(timer);
+            pin!(observations);
+
+            /*
+            TODO: it looks like yield cannot be used from within a closure. Consider
+            // verifying and filing a bug if that's the case.
+            // A helper with yield syntax. This is how we run the engine, dumping
+            // an item to the stream only if its actionable.
+            let compute_next = || {
+                if let Some(action) = engine.compute() {
+                    yield action;
+                }
+            };
+            */
+
+            // • Check to see if we can read a new observation.
+            loop {
+                select! {
+                    _ = timer.next() => {
+                        // • Timer has ticked! Run the engine and check for the results.
+                        // compute_next();
+                        if let Some(action) = engine.compute() {
+                            yield action;
+                        }
+                    }
+                    observation = observations.next() => {
+                        match observation {
+                            Some(obs) => {
+                                for observ in obs {
+                                    engine.add_observation(observ);
+                                }
+                            },
+                            // Nothing left for us to compute.
+                            // Run the engine one last time and exit.
+                            None => {
+                                // compute_next();
+                                if let Some(action) = engine.compute() {
+                                    yield action;
+                                }
+                                break;
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/adapters/engines/mod.rs
+++ b/src/adapters/engines/mod.rs
@@ -1,0 +1,14 @@
+/// The decision engine receives observations from the monitor
+/// and determines whether the canary should be promoted, yanked,
+/// or scaled up or down.
+pub trait DecisionEngine {}
+pub struct MockEngine;
+impl DecisionEngine for MockEngine {}
+
+impl From<MockEngine> for BoxEngine {
+    fn from(value: MockEngine) -> Self {
+        Box::new(value)
+    }
+}
+
+pub type BoxEngine = Box<dyn DecisionEngine>;

--- a/src/adapters/engines/mod.rs
+++ b/src/adapters/engines/mod.rs
@@ -1,14 +1,44 @@
+use crate::stats::EnumerableCategory;
+use std::hash::Hash;
+
+pub use action::Action;
+
+/// Helper trait, since these requirements are often used by
+/// our implementation of `ContingencyTables`.
+trait HashableCategory: EnumerableCategory + Hash + Eq {}
+impl<T: EnumerableCategory + Hash + Eq> HashableCategory for T {}
+
+// TODO: We probably want to define an "EngineController" type that wraps the execution
+//       of the engine with extra configurables, like "how often do we run the engine"
+//       and "how many samples do we need before we run the engine again?"
+//       The EngineController can also handle the async threading and stream interactions.
+
 /// The decision engine receives observations from the monitor
 /// and determines whether the canary should be promoted, yanked,
 /// or scaled up or down.
-pub trait DecisionEngine {}
-pub struct MockEngine;
-impl DecisionEngine for MockEngine {}
+pub trait DecisionEngine<T: HashableCategory> {
+    /// [add_observation] provides a new observation that the engine
+    /// should take under advisement before making a decision.
+    fn add_observation(&mut self, observation: T);
 
-impl From<MockEngine> for BoxEngine {
-    fn from(value: MockEngine) -> Self {
-        Box::new(value)
+    /// [compute] will ask the engine to run over all known observations.
+    /// The engine isn't required to output an [Action]. It might determine
+    /// there isn't enough data to make an affirmative decision.
+    fn compute(&mut self) -> Option<Action>;
+}
+
+pub struct MockEngine;
+impl<T: HashableCategory> DecisionEngine<T> for MockEngine {
+    fn add_observation(&mut self, _: T) {
+        todo!();
+    }
+
+    fn compute(&mut self) -> Option<Action> {
+        todo!()
     }
 }
 
-pub type BoxEngine = Box<dyn DecisionEngine>;
+// TODO: maybe this should be a nutype.
+pub type BoxEngine<T: HashableCategory> = Box<dyn DecisionEngine<T>>;
+
+mod action;

--- a/src/adapters/ingresses/mod.rs
+++ b/src/adapters/ingresses/mod.rs
@@ -1,0 +1,14 @@
+pub trait Ingress {}
+
+pub struct MockIngress;
+impl Ingress for MockIngress {}
+
+impl From<MockIngress> for BoxIngress {
+    fn from(value: MockIngress) -> Self {
+        Box::new(value)
+    }
+}
+
+/// Convenience alias since this type is often dynamically
+/// dispatched.
+pub type BoxIngress = Box<dyn Ingress>;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -58,7 +58,8 @@ mod monitors;
 #[cfg(test)]
 mod tests {
     use crate::adapters::Observation;
-    use crate::stats::{Group, StatusCategory};
+    use crate::metrics::ResponseStatusCode;
+    use crate::stats::Group;
 
     use super::{CloudwatchLogs, ObservationEmitter};
 
@@ -70,7 +71,7 @@ mod tests {
         fn emit_next(&mut self) -> Vec<super::Observation> {
             vec![Observation {
                 group: Group::Control,
-                outcome: StatusCategory::_2XX,
+                outcome: ResponseStatusCode::_2XX,
             }]
         }
     }

--- a/src/adapters/monitors/mod.rs
+++ b/src/adapters/monitors/mod.rs
@@ -1,0 +1,72 @@
+use async_trait::async_trait;
+use tokio::{pin, time::interval};
+use tokio_stream::{wrappers::IntervalStream, StreamExt};
+
+/// The maximum number of observations that can be recevied before we
+/// recompute statistical significance.
+/// If this number is too low, we'll be performing compute-intensive
+/// statical tests very often. If this number is too high, we could
+/// be waiting too long before computing, which could permit us to promote more eagerly.
+const DEFAULT_BATCH_SIZE: usize = 512;
+
+/// An [Observer] watches a particular external system (like AWS CloudWatch Logs)
+/// and converts them into observations before emitting them as a stream.
+#[async_trait]
+pub trait Monitor {
+    /// The kind of object emitted by the Observer.
+    type Item;
+
+    /// The [query] method will query the observable external system on demand
+    /// and produce a collection of observations. This collection of observations
+    /// is supposed to represent the set that occurred since the last time this
+    /// function was called.
+    // TODO: This should return a result which we should account for in error handling.
+    async fn query(&mut self) -> Vec<Self::Item>;
+}
+
+// TODO: Add a call to chunk_timeout to ensure that items are arriving after a particular
+//       amount of time.
+/// [repeat_query] runs the query on an interval and returns a stream of items.
+/// This function runs indefinitely.
+pub fn repeat_query<T: Monitor>(
+    mut observer: T,
+    duration: tokio::time::Duration,
+) -> impl tokio_stream::Stream<Item = T::Item> {
+    // • Everything happens in this stream closure, which desugars
+    //   into a background thread and a channel write at yield points.
+    async_stream::stream! {
+        // • Initialize a timer that fires every interval.
+        let timer = IntervalStream::new(interval(duration));
+        // • The timer must be pinned to use in an iterator
+        //   because we must promise that its address must not
+        //   be moved between iterations.
+        pin!(timer);
+        // Each iteration of the loop represents one unit of tiem.
+        while timer.next().await.is_some() {
+            // • We perform the query then dump the results into the stream.
+            let items = observer.query().await;
+            for item in items {
+                yield item;
+            }
+        }
+    }
+}
+
+// TODO: Honestly, this function can be inlined where used.
+/// Batch observations together into maximally sized chunks, and dump
+/// them to a stream every so often.
+pub fn batch_observations<T: Monitor>(
+    obs: impl tokio_stream::Stream<Item = T::Item>,
+    duration: tokio::time::Duration,
+) -> impl tokio_stream::Stream<Item = Vec<T::Item>> {
+    obs.chunks_timeout(DEFAULT_BATCH_SIZE, duration)
+}
+
+#[cfg(test)]
+mod tests {
+    use static_assertions::assert_obj_safe;
+
+    use super::Monitor;
+
+    assert_obj_safe!(Monitor<Item = ()>);
+}

--- a/src/cmd/version.rs
+++ b/src/cmd/version.rs
@@ -9,7 +9,7 @@ pub struct Version;
 
 impl Version {
     pub fn new() -> Self {
-        Self::default()
+        Self
     }
 
     /// Print the version and exit.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ mod adapters;
 mod cmd;
 /// configuration of the CLI, either from the environment of flags.
 mod config;
+/// Contains the definitions of metrics that are valuable to detecting
+/// canary health. Currently, ResponseStatusCode is the only metric of note.
+pub mod metrics;
 mod pipeline;
 /// Our statistics library.
 pub mod stats;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,13 @@
-#![allow(dead_code)]
-
 pub use config::Flags;
 
-/// An adapter connects to some observable resource (like CloudWatch) and
+/// An adapter connects to some observable resource (like `CloudWatch`) and
 /// emits events, like failed and succeeded requests.
-mod adapter;
+mod adapters;
 /// Contains the dispatch logic for running individual CLI subcommands.
 /// The CLI's main function calls into these entrypoints for each subcommand.
 mod cmd;
 /// configuration of the CLI, either from the environment of flags.
 mod config;
-/// This is the data pipeline responsible for the control flow
-/// of data from observers into number crunchers.
 mod pipeline;
 /// Our statistics library.
 pub mod stats;

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,0 +1,24 @@
+use crate::stats::EnumerableCategory;
+
+/// [ResponseStatusCode] groups HTTP response status codes according
+/// to five general categories. This type is used as the dependent
+/// variable in statical observations.
+#[derive(Hash, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum ResponseStatusCode {
+    // Information responses
+    _1XX,
+    // Successful responses
+    _2XX,
+    // Redirection messages
+    _3XX,
+    // Client error responses
+    _4XX,
+    // Server error responses
+    _5XX,
+}
+
+impl EnumerableCategory for ResponseStatusCode {
+    fn groups() -> Box<dyn Iterator<Item = Self>> {
+        Box::new([Self::_1XX, Self::_2XX, Self::_3XX, Self::_4XX, Self::_5XX].into_iter())
+    }
+}

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,12 +1,17 @@
+#[cfg(test)]
 use crate::{
-    adapters::{DecisionEngine, Ingress, MockEngine, MockIngress, Monitor},
+    adapters::{DecisionEngine, Ingress, MockIngress, Monitor},
     metrics::ResponseStatusCode,
     stats::Observation,
 };
 
+#[cfg(test)]
+use crate::adapters::AlwaysPromote;
+
 // TODO: Add some more structure to this. Right now, I'm
 //       just trying to get the general layout defined and
-//       all of the actors wired up.
+//       all of the actors wired up
+#[cfg(test)]
 pub async fn setup_pipeline() {
     // • First, we create a monitor based on the configuration we've been given.
     //   It must use dynamic dispatch because we're not sure what kind of
@@ -14,7 +19,7 @@ pub async fn setup_pipeline() {
     let _monitor: Option<Box<dyn Monitor<Item = Observation>>> = None;
     // • Repeat for the Ingress and the Engine.
     let _ingress: Box<dyn Ingress> = Box::new(MockIngress);
-    let _engine: Box<dyn DecisionEngine<ResponseStatusCode>> = Box::new(MockEngine);
+    let _engine: Box<dyn DecisionEngine<ResponseStatusCode>> = Box::new(AlwaysPromote);
 
     // TODO:
     // Define the APIs that each of these things use.

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,72 +1,18 @@
-use async_trait::async_trait;
-use tokio::{pin, time::interval};
-use tokio_stream::{wrappers::IntervalStream, StreamExt};
+use crate::{
+    adapters::{DecisionEngine, Ingress, MockEngine, MockIngress, Monitor},
+    stats::Observation,
+};
 
-/// The maximum number of observations that can be recevied before we
-/// recompute statistical significance.
-/// If this number is too low, we'll be performing compute-intensive
-/// statical tests very often. If this number is too high, we could
-/// be waiting too long before computing, which could permit us to promote more eagerly.
-const DEFAULT_BATCH_SIZE: usize = 512;
-
-/// An [Observer] watches a particular external system (like AWS CloudWatch Logs)
-/// and converts them into observations before emitting them as a stream.
-#[async_trait]
-pub trait Observer {
-    /// The kind of object emitted by the Observer.
-    type Item;
-
-    /// The [query] method will query the observable external system on demand
-    /// and produce a collection of observations. This collection of observations
-    /// is supposed to represent the set that occurred since the last time this
-    /// function was called.
-    // TODO: This should return a result which we should account for in error handling.
-    async fn query(&mut self) -> Vec<Self::Item>;
-}
-
-// TODO: Add a call to chunk_timeout to ensure that items are arriving after a particular
-//       amount of time.
-/// [repeat_query] runs the query on an interval and returns a stream of items.
-/// This function runs indefinitely.
-pub fn repeat_query<T: Observer>(
-    mut observer: T,
-    duration: tokio::time::Duration,
-) -> impl tokio_stream::Stream<Item = T::Item> {
-    // • Everything happens in this stream closure, which desugars
-    //   into a background thread and a channel write at yield points.
-    async_stream::stream! {
-        // • Initialize a timer that fires every interval.
-        let timer = IntervalStream::new(interval(duration));
-        // • The timer must be pinned to use in an iterator
-        //   because we must promise that its address must not
-        //   be moved between iterations.
-        pin!(timer);
-        // Each iteration of the loop represents one unit of tiem.
-        while timer.next().await.is_some() {
-            // • We perform the query then dump the results into the stream.
-            let items = observer.query().await;
-            for item in items {
-                yield item;
-            }
-        }
-    }
-}
-
-// TODO: Honestly, this function can be inlined where used.
-/// Batch observations together into maximally sized chunks, and dump
-/// them to a stream every so often.
-pub fn batch_observations<T: Observer>(
-    obs: impl tokio_stream::Stream<Item = T::Item>,
-    duration: tokio::time::Duration,
-) -> impl tokio_stream::Stream<Item = Vec<T::Item>> {
-    obs.chunks_timeout(DEFAULT_BATCH_SIZE, duration)
-}
-
-#[cfg(test)]
-mod tests {
-    use static_assertions::assert_obj_safe;
-
-    use super::Observer;
-
-    assert_obj_safe!(Observer<Item = ()>);
+// TODO: Add some more structure to this. Right now, I'm
+//       just trying to get the general layout defined and
+//       all of the actors wired up.
+pub async fn setup_pipeline() {
+    // • First, we create a monitor based on the configuration we've been given.
+    //   It must use dynamic dispatch because we're not sure what kind of
+    //   monitor it is.
+    let _monitor: Option<Box<dyn Monitor<Item = Observation>>> = None;
+    // • Repeat for the Ingress and the Engine.
+    let _ingress: Box<dyn Ingress> = Box::new(MockIngress);
+    let _engine: Box<dyn DecisionEngine> = Box::new(MockEngine);
+    todo!();
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     adapters::{DecisionEngine, Ingress, MockEngine, MockIngress, Monitor},
+    metrics::ResponseStatusCode,
     stats::Observation,
 };
 
@@ -13,6 +14,13 @@ pub async fn setup_pipeline() {
     let _monitor: Option<Box<dyn Monitor<Item = Observation>>> = None;
     // • Repeat for the Ingress and the Engine.
     let _ingress: Box<dyn Ingress> = Box::new(MockIngress);
-    let _engine: Box<dyn DecisionEngine> = Box::new(MockEngine);
+    let _engine: Box<dyn DecisionEngine<ResponseStatusCode>> = Box::new(MockEngine);
+
+    // TODO:
+    // Define the APIs that each of these things use.
+
+    // TODO:
+    // Now that these types are defined, let's wire them together.
+    // The DecisionEngine actor takes a stream of Event batches.
     todo!();
 }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 pub use chi::EnumerableCategory;
 
+use crate::metrics::ResponseStatusCode;
+
 /// The alpha cutoff is the amount of confidence must have in the result
 /// to feel comfortable that the result is not due to chance, but instead
 /// do to the independent variable. The valu is expressed as a confidence
@@ -57,11 +59,11 @@ impl ChiSquareEngine {
     pub fn calc_test_statistic(&self) -> f64 {
         let mut error = 0.0;
         let categories = [
-            StatusCategory::_1XX,
-            StatusCategory::_2XX,
-            StatusCategory::_3XX,
-            StatusCategory::_4XX,
-            StatusCategory::_5XX,
+            ResponseStatusCode::_1XX,
+            ResponseStatusCode::_2XX,
+            ResponseStatusCode::_3XX,
+            ResponseStatusCode::_4XX,
+            ResponseStatusCode::_5XX,
         ];
         // For each category, we calculate the squared error between the
         // expected and the observed probabilies.
@@ -74,14 +76,14 @@ impl ChiSquareEngine {
     }
 
     /// calculate the expected frequency for this category.
-    fn expected_frequency(&self, category: StatusCategory) -> f64 {
+    fn expected_frequency(&self, category: ResponseStatusCode) -> f64 {
         let observation_count = self.control[&category] as f64;
         let total_count = self.control[&category] as f64;
         observation_count / total_count
     }
 
     /// calculate the observed frequency for this category.
-    fn observed_frequency(&self, category: StatusCategory) -> f64 {
+    fn observed_frequency(&self, category: ResponseStatusCode) -> f64 {
         let observation_count = self.experimental[&category] as f64;
         let total_count = self.experimental[&category] as f64;
         observation_count / total_count
@@ -89,7 +91,7 @@ impl ChiSquareEngine {
 }
 
 /// This type maps the dependent variable to its count.
-pub type ContingencyTable = HashMap<StatusCategory, usize>;
+pub type ContingencyTable = HashMap<ResponseStatusCode, usize>;
 
 /// An [Observation] represents a measured outcome that
 /// belongs to either a control group or an experimental
@@ -98,7 +100,7 @@ pub struct Observation {
     /// The experimental group or the control group.
     pub group: Group,
     /// The outcome of the observation, by status code.
-    pub outcome: StatusCategory,
+    pub outcome: ResponseStatusCode,
 }
 
 /// The [Group] indicates from whence a given observation
@@ -110,23 +112,6 @@ pub enum Group {
     Control,
     /// The experimental group represents the canary deployment.
     Experimental,
-}
-
-/// [StatusCategory] groups HTTP response status codes according
-/// to five general categories. This type is used as the dependent
-/// variable in statical observations.
-#[derive(Hash, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
-pub enum StatusCategory {
-    // Information responses
-    _1XX,
-    // Successful responses
-    _2XX,
-    // Redirection messages
-    _3XX,
-    // Client error responses
-    _4XX,
-    // Server error responses
-    _5XX,
 }
 
 /// contains the engine to calculate the chi square test statistic.


### PR DESCRIPTION
Restructure app to use actor architecture

This commit defines the core "actors" in Canary as the "monitor",
"the ingress", and the "decision engine", and structures the app
around the adapters facilitating those three operations.

--------

Add Methods on DecisionEngine and Create Metrics Module

I extracted the "observation type" type definitions into a module
called "metrics" to more closely reflect that the observations
could be other types of metrics, like CPU and RAM usage, in addition
to response codes.

I also added a little more detail to the trait definition of the
decision engine.

-------

Add an EngineController type that converts the Engine into a stream.

This commit introduces an EngineController, which is a wrapper
around the DecisionEngine interface that controls when the Engine
should be called. Its intended to be where configuration around
number of samples and timeouts are implemented.